### PR TITLE
Update google-p12-pem dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "google-p12-pem": "^0.0.1",
+    "google-p12-pem": "^0.0.2",
     "jws": "^3.0.0",
     "mime": "^1.2.11",
     "request": "^2.55.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "google-p12-pem": "^0.0.2",
+    "google-p12-pem": "^0.1.0",
     "jws": "^3.0.0",
     "mime": "^1.2.11",
     "request": "^2.55.0"


### PR DESCRIPTION
Sorry to keep doing this to you!
so this package doesn't use the new version of google-p12-pem (with the updated node-forge package dep) that we just updated. I think that it doesn't auto pull in the new version because npm semver still thinks google-p12-pem is in beta due to its 0.0.x version number. 
Thanks!