### PR TITLE
Update `google-p12-pem` to latest version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "google-p12-pem": "^0.1.0",
+    "google-p12-pem": "^0.1.1",
     "jws": "^3.0.0",
     "mime": "^1.2.11",
     "request": "^2.72.0"


### PR DESCRIPTION
Update `google-p12-pem` to pick up https://github.com/ryanseys/google-p12-pem/commit/20b7c386b70ed23bfa3c33620b2dfa287ddba5c5.