### PR TITLE
Add missing `return` statements.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ GoogleToken.prototype.getToken = function(callback) {
   var self = this;
 
   if (!this.hasExpired()) {
-    callback(null, this.token);
+    return callback(null, this.token);
   } else {
     if (!this.key && !this.keyFile) {
       callback(new Error('No key or keyFile set.'));
@@ -74,7 +74,7 @@ GoogleToken.prototype.getToken = function(callback) {
         }
       }
     } else {
-      this._requestToken(callback);
+      return this._requestToken(callback);
     }
   }
 
@@ -192,13 +192,13 @@ GoogleToken.prototype._requestToken = function(callback) {
     secret: this.key
   };
 
-  this._signJWT(toSign, function(err, signedJWT) {
+  return this._signJWT(toSign, function(err, signedJWT) {
     if (err) {
       callback(err, null);
       return;
     }
 
-    self._request({
+    return self._request({
       method: 'post',
       url: GOOGLE_TOKEN_URL,
       form: {
@@ -224,7 +224,7 @@ GoogleToken.prototype._requestToken = function(callback) {
       self.raw_token = body;
       self.token = body.access_token;
       self.expires_at = (iat + body.expires_in) * 1000;
-      callback(null, self.token);
+      return callback(null, self.token);
     });
   });
 };
@@ -238,7 +238,7 @@ GoogleToken.prototype._requestToken = function(callback) {
 GoogleToken.prototype._signJWT = function(opts, callback) {
   try {
     var signedJWT = jws.sign(opts);
-    callback(null, signedJWT);
+    return callback(null, signedJWT);
   } catch (err) {
     callback(err, null);
   }


### PR DESCRIPTION
These missing `return` statements causes a Google Sheets `get` request to
be undefined, when used with the Promise-compatible `googleapis-promise`
library.

Specifically, this code breaks:

```javascript
const google = require('googleapis-promise');
let r = await google.sheets('v4').spreadsheets.values.get(request).promise;
// TypeError: Cannot read property 'promise' of undefined
```

Once these `return` statements are added, the correct values are passed
back up the chain to the calling function.